### PR TITLE
"Auto update" by pulling latest release from github

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,9 +132,9 @@
               <ul style="list-style-type:none;">
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-x64.exe">
+                    <a id="winx64-installer-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-x64.exe">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 x64
+                      <span id="winx64-installer-version"></span> x64
                     </a>
                     <span class="minor-text">
                     <!-- Keeping this one empty for now, hoping that the other descriptions make it clear. /!-->             
@@ -143,9 +143,9 @@
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-arm64.exe">
+                    <a id="winarm-installer-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-arm64.exe">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 ARM
+                      <span id="winarm-installer-version"></span> ARM
                     </a>
                     <span class="minor-text">
                       &ensp;&ensp;(Rare)                
@@ -154,9 +154,9 @@
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-x86.exe">
+                    <a id="winx86-installer-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-x86.exe">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 x86
+                      <span id="winx86-installer-version"></span> x86
                     </a>
                     <span class="minor-text">
                       &ensp;&ensp;&ensp;(Legacy)                
@@ -171,9 +171,9 @@
               <ul style="list-style-type:none;">
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Windows_x64.zip">
+                    <a id="winx64-pack-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Windows_x64.zip">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 x64 
+                      <span id="winx64-pack-version"></span> x64 
                     </a>
                     <span class="minor-text">
                     <!-- Keeping this one empty for now, hoping that the other descriptions make it clear. /!-->             
@@ -182,9 +182,9 @@
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Windows_arm64.zip">
+                    <a id="winarm-pack-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Windows_arm64.zip">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 ARM
+                      <span id="winarm-pack-version"></span> ARM
                     </a>
                     <span class="minor-text">
                       &ensp;&ensp;(Rare)                
@@ -193,9 +193,9 @@
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Windows_x86.zip">
+                    <a id="winx86-pack-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Windows_x86.zip">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 x86
+                      <span id="winx86-pack-version"></span> x86
                     </a>
                     <span class="minor-text">
                       &ensp;&ensp;&ensp;(Legacy)                
@@ -219,9 +219,9 @@
               <ul style="list-style-type:none;">
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0.dmg">
+                    <a id="macuni-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0.dmg">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 DMG
+                      <span id="macuni-version"></span> DMG
                     </a>
                     <span class="minor-text">
                     <!-- Keeping this one empty for now, hoping that the other descriptions make it clear. /!-->             
@@ -236,9 +236,9 @@
               <ul style="list-style-type:none;">
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/MacOS_arm64.tar.gz">
+                    <a id="macapplesilicon-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/MacOS_arm64.tar.gz">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 Apple Silicon 
+                      <span id="macapplesilicon-version"></span> Apple Silicon 
                     </a>
                     <span class="minor-text">
                       &ensp;&ensp;(M1, M2, or M3)            
@@ -247,9 +247,9 @@
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/MacOS_x64.tar.gz">
+                    <a id="macintel-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/MacOS_x64.tar.gz">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 Intel
+                      <span id="macintel-version"></span> Intel
                     </a>
                     <span class="minor-text">
                       &ensp;&ensp;
@@ -278,17 +278,17 @@
               <ul style="list-style-type:none;">
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-x86_64.AppImage">
+                    <a id="linuxx64-appimage-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-x86_64.AppImage">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 x64 
+                      <span id="linuxx64-appimage-version"></span> x64 
                     </a>
                   </h5>
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-aarch64.AppImage">
+                    <a id="linuxarm-appimage-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-aarch64.AppImage">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 ARM
+                      <span id="linuxarm-appimage-version"></span> ARM
                     </a>
                     <span class="minor-text">                      
                       <br>
@@ -305,17 +305,17 @@
               <ul style="list-style-type:none;">
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Linux_x64.tar.gz">
+                    <a  id="linuxx64-binaries-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Linux_x64.tar.gz">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 x64 
+                      <span id="linuxx64-binaries-version"></span> x64 
                     </a>
                   </h5>                 
                 </li>
                 <li>
                   <h5>
-                    <a class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Linux_arm64.tar.gz">
+                    <a id="linuxarm-binaries-link" class="local-link" href="https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Linux_arm64.tar.gz">
                       <img length="10" width="10" src="main/res/iconmonstr-download.png"/>
-                      1.0.0 ARM
+                      <span id="linuxarm-binaries-version"></span> ARM
                     </a>
                   </h5>                 
                 </li>

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
     <div class="lower-navbar">
       <h5>
         <a target="_blank" rel="noopener noreferrer" href="https://github.com/KnossosNET/Knossos-Release-Page/issues">
-          Report Page Issue  
+          Report Page Issues  
         </a>
         
         &ensp;<b>|</b>&ensp;        

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -1,4 +1,4 @@
-const fallbackVersion = "test"
+const fallbackVersion = "1.0.0"
 
 const buildMatrix = {
   windows: {
@@ -68,8 +68,7 @@ function initPage(arch){
 
   fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
     .then((response) => response.json())
-    .then((responseJSON) => get_info(responseJSON))
-    .then(populateFields(true))
+    .then(responseJSON => { get_info(responseJSON); populateFields(true); })
     .catch (error => console.log(`Fetching the most recent build from the github api failed. The error encountered was: ${error}`));
   
   // still looking for a good ARM list.  Hopefully defaulting to ARM and detecting the other two is enough.

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -1,6 +1,6 @@
 // Installer: ARM, x64, x86 THEN Portable: ARM, x64, x86
 const windowsLinks = [
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-arm64.exe", 
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-arm64.ex", 
   "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-x64.exe", 
   "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-x86.exe",
   "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_arm64.zip",

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -371,22 +371,22 @@ function get_info(response){
       continue;
     }
 
-    if (response.assets[x].name.slice(-9)=== "arm64.exe"){
+    if (response.assets[x].name.endsWith("arm64.exe")){
       buildMatrix.windows.arm64Installer.version = newVersion;
       buildMatrix.windows.arm64Installer.url = response.assets[x].browser_download_url;
-    } else if (response.assets[x].name.slice(-7)==="x64.exe"){
+    } else if (response.assets[x].name.endsWith("x64.exe")){
       buildMatrix.windows.x64Installer.version = newVersion;
       buildMatrix.windows.x64Installer.url = response.assets[x].browser_download_url;
-    } else if (response.assets[x].name.slice(-7)==="x86.exe"){
+    } else if (response.assets[x].name.endsWith("x86.exe")){
       buildMatrix.windows.x86Installer.version = newVersion;
       buildMatrix.windows.x86Installer.url = response.assets[x].browser_download_url;
-    } else if (response.assets[x].name.slice(-4)===".dmg"){
+    } else if (response.assets[x].name.endsWith(".dmg")){
       buildMatrix.macos.installer.version = newVersion;
       buildMatrix.macos.installer.url = response.assets[x].browser_download_url;
-    } else if (response.assets[x].name.slice(-16)==="aarch64.AppImage"){
+    } else if (response.assets[x].name.endsWith("aarch64.AppImage")){
       buildMatrix.linux.arm64Installer.version = newVersion;
       buildMatrix.linux.arm64Installer.url = response.assets[x].browser_download_url;
-    } else if (response.assets[x].name.slice(-15)==="x86_64.AppImage"){
+    } else if (response.assets[x].name.endsWith("x86_64.AppImage")){
       buildMatrix.linux.x64Installer.version = newVersion;
       buildMatrix.linux.x64Installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="Linux_arm64.tar.gz"){

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -1,3 +1,52 @@
+// Installer: ARM, x64, x86 THEN Portable: ARM, x64, x86
+const windowsLinks = [
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-arm64.exe", 
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-x64.exe", 
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-x86.exe",
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_arm64.zip",
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_x64.zip",
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_x86.zip"
+];
+
+const windowsVersions = [
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10"
+]
+
+// Universal, then Apple Silicon, Then Intel
+const macLinks = [
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10.dmg",
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/MacOS_arm64.tar.gz", 
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/MacOS_x64.tar.gz"
+];
+
+const macVersions = [
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10"
+]
+
+// Appimage: aarch64, x86_64 THEN Precombiled Binaries aarch64, x86_64
+const linuxLinks = [
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-aarch64.AppImage", 
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-x86_64.AppImage",
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Linux_arm64.tar.gz",
+  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Linux_x64.tar.gz"
+];
+
+const linuxVersions = [
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10",
+  "0.2.0-RC10"
+]
+
+const latestManualVersion = "0.2.0-RC10";
+
 // Run at the start of the page (called from the html) with our best guess at 
 function initPage(arch){
   // still looking for a good ARM list.  Hopefully defaulting to ARM and detecting the other two is enough.
@@ -13,6 +62,13 @@ function initPage(arch){
   }
 
   initOsChoice(archResult);
+
+  populateFields();
+
+  let response = fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
+  .then((response) => response.json())
+  .then((json) => console.log(json));
+
 }
 
 // Change tab appearance and download link contents
@@ -141,15 +197,15 @@ function activateTheButton(os, arch){
   if (os === 0) {
     if (arch === 0){
       newContents += "Windows ARM64 Installer";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-arm64.exe";
+      anchorElement.href = windowsLinks[0];
 
     } else if (arch === 32) {
       newContents +=  "Windows 32 Bit Installer";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-x86.exe";
+      anchorElement.href = windowsLinks[2];
     
     } else if (arch === 64) {
       newContents +=  "Windows 64 Bit Intel Installer";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0-x64.exe";
+      anchorElement.href = windowsLinks[1];
 
     // Bogus Windows arch
     }  else {
@@ -160,17 +216,14 @@ function activateTheButton(os, arch){
   // Mac
   } else if (os === 1) {
 
-    if (arch === 0) {  
+    // Because of universal build, handle both situations at once.
+    if (arch === 0 || arch === 64) {  
       newContents += "Mac Universal DMG";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0.dmg";
+      anchorElement.href = macLinks[0];
 
     } else if (arch === 32) {
       // Unsuppoted
       disableTheButton();
-
-    } else if (arch === 64) {
-      newContents +=  "Mac Universal DMG";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-1.0.0.dmg";
 
     // Bogus Mac Arch, (Or so old, we're wondering how they're still using it)
     } else {
@@ -182,7 +235,7 @@ function activateTheButton(os, arch){
   } else if (os === 2) {
     if (arch === 0) {
       newContents +=  "Linux aarch64 AppImage";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-aarch64.AppImage";
+      anchorElement.href = linuxLinks[0];
 
     } else if (arch === 32) {
         // Unsupported
@@ -190,7 +243,7 @@ function activateTheButton(os, arch){
 
     } else if (arch === 64) {
       newContents += "Linux x86_64 AppImage";
-      anchorElement.href = "https://github.com/KnossosNET/Knossos.NET/releases/download/v1.0.0/Knossos.NET-x86_64.AppImage";
+      anchorElement.href = linuxLinks[1];
 
     // Bogus Linux Arch
     } else {
@@ -215,4 +268,41 @@ function activateTheButton(os, arch){
 
   // Go ahead and let the user see it
   activateDownload();
+}
+
+function populateFields(){
+
+  document.getElementById("winarm-installer-version").innerHTML = windowsVersions[0];
+  document.getElementById("winx64-installer-version").innerHTML = windowsVersions[1];
+  document.getElementById("winx86-installer-version").innerHTML = windowsVersions[2];
+  document.getElementById("winarm-pack-version").innerHTML = windowsVersions[3];
+  document.getElementById("winx64-pack-version").innerHTML = windowsVersions[4];
+  document.getElementById("winx86-pack-version").innerHTML = windowsVersions[5];
+
+  document.getElementById("winarm-installer-link").href = windowsLinks[0];
+  document.getElementById("winx64-installer-link").href = windowsLinks[1];
+  document.getElementById("winx86-installer-link").href = windowsLinks[2];
+  document.getElementById("winarm-pack-link").href = windowsLinks[3];
+  document.getElementById("winx64-pack-link").href = windowsLinks[4];
+  document.getElementById("winx86-pack-link").href = windowsLinks[5];
+
+
+  document.getElementById("macuni-version").innerHTML = macVersions[0];
+  document.getElementById("macapplesilicon-version").innerHTML = macVersions[1];
+  document.getElementById("macintel-version").innerHTML = macVersions[2];
+
+  document.getElementById("macuni-link").href = macLinks[0];
+  document.getElementById("macapplesilicon-link").href = macLinks[1];
+  document.getElementById("macintel-link").href = macLinks[2];
+
+
+  document.getElementById("linuxarm-appimage-version").innerHTML = linuxVersions[0];
+  document.getElementById("linuxx64-appimage-version").innerHTML = linuxVersions[1];
+  document.getElementById("linuxarm-binaries-version").innerHTML = linuxVersions[2];
+  document.getElementById("linuxx64-binaries-version").innerHTML = linuxVersions[3];
+
+  document.getElementById("linuxarm-appimage-link").href = linuxLinks[0];
+  document.getElementById("linuxx64-appimage-link").href = linuxLinks[1];
+  document.getElementById("linuxarm-binaries-link").href = linuxLinks[2];
+  document.getElementById("linuxx64-binaries-link").href = linuxLinks[3];
 }

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -49,6 +49,13 @@ const latestManualVersion = "0.2.0-RC10";
 
 // Run at the start of the page (called from the html) with our best guess at 
 function initPage(arch){
+  populateFields();
+
+  fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
+  .then((response) => response.json())
+  .then((responseJSON) => get_info(responseJSON))
+  .then(populateFields);
+
   // still looking for a good ARM list.  Hopefully defaulting to ARM and detecting the other two is enough.
   const arch64List = ["EM64T", "x86-64", "Intel 64", "amd64"];
   const arch32List = ["ia32", "x86", "amd32"];
@@ -62,13 +69,6 @@ function initPage(arch){
   }
 
   initOsChoice(archResult);
-
-  populateFields();
-
-  let response = fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
-  .then((response) => response.json())
-  .then((json) => console.log(json));
-
 }
 
 // Change tab appearance and download link contents
@@ -305,4 +305,70 @@ function populateFields(){
   document.getElementById("linuxx64-appimage-link").href = linuxLinks[1];
   document.getElementById("linuxarm-binaries-link").href = linuxLinks[2];
   document.getElementById("linuxx64-binaries-link").href = linuxLinks[3];
+}
+
+function get_info(response){
+  console.log(response);
+
+  if (!response || !response.hasOwnProperty("assets")){
+
+    console.log("Early return. Response is null or does not have assets");
+    return;
+  }
+
+  let newVersion = latestManualVersion;
+
+  if (response.hasOwnProperty("tag_name")){
+    newVersion = response.tag_name;
+  }
+
+  let x = 0;
+
+  while (x < response.assets.length){
+    if (!response.assets[x].hasOwnProperty("name") || !response.assets[x].hasOwnProperty("browser_download_url")){
+      continue;
+    }
+
+    if (response.assets[x].name.slice(-9)=== "arm64.exe"){
+      windowsVersions[0] = newVersion;
+      windowsLinks[0] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name.slice(-7)==="x64.exe"){
+      windowsVersions[1] = newVersion;
+      windowsLinks[1] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name.slice(-7)==="x86.exe"){
+      windowsVersions[2] = newVersion;
+      windowsLinks[2] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name.slice(-4)===".dmg"){
+      macVersions[0] = newVersion;
+      macLinks[0] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name.slice(-16)==="aarch64.AppImage"){
+      linuxVersions[0] = newVersion;
+      linuxLinks[0] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name.slice(-15)==="x86_64.AppImage"){
+      linuxVersions[1] = newVersion;
+      linuxLinks[1] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name==="Linux_arm64.tar.gz"){
+      linuxVersions[2] = newVersion;
+      linuxLinks[2] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name==="Linux_x64.tar.gz"){
+      linuxVersions[3] = newVersion;
+      linuxLinks[3] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name==="MacOS_arm64.tar.gz"){
+      macVersions[1] = newVersion;
+      macLinks[1] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name==="MacOS_x64.tar.gz"){
+      macVersions[2] = newVersion;
+      macLinks[2] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name==="Windows_arm64.zip"){
+      windowsVersions[3] = newVersion;
+      windowsLinks[3] = response.assets[x].browser_download_url;
+    } else if (response.assets[x].name==="Windows_x64.zip"){
+      windowsVersions[4] = newVersion;
+      windowsLinks[4] = response.assets[x].browser_download_url;      
+    } else if (response.assets[x].name==="Windows_x86.zip"){
+      windowsVersions[5] = newVersion;
+      windowsLinks[5] = response.assets[x].browser_download_url;      
+    }
+    x++;
+  }
 }

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -272,12 +272,12 @@ function activateTheButton(os, arch){
 
 function populateFields(){
 
-  document.getElementById("winarm-installer-version").innerHTML = windowsVersions[0];
-  document.getElementById("winx64-installer-version").innerHTML = windowsVersions[1];
-  document.getElementById("winx86-installer-version").innerHTML = windowsVersions[2];
-  document.getElementById("winarm-pack-version").innerHTML = windowsVersions[3];
-  document.getElementById("winx64-pack-version").innerHTML = windowsVersions[4];
-  document.getElementById("winx86-pack-version").innerHTML = windowsVersions[5];
+  document.getElementById("winarm-installer-version").textContent = windowsVersions[0];
+  document.getElementById("winx64-installer-version").textContent = windowsVersions[1];
+  document.getElementById("winx86-installer-version").textContent = windowsVersions[2];
+  document.getElementById("winarm-pack-version").textContent = windowsVersions[3];
+  document.getElementById("winx64-pack-version").textContent = windowsVersions[4];
+  document.getElementById("winx86-pack-version").textContent = windowsVersions[5];
 
   document.getElementById("winarm-installer-link").href = windowsLinks[0];
   document.getElementById("winx64-installer-link").href = windowsLinks[1];
@@ -287,19 +287,19 @@ function populateFields(){
   document.getElementById("winx86-pack-link").href = windowsLinks[5];
 
 
-  document.getElementById("macuni-version").innerHTML = macVersions[0];
-  document.getElementById("macapplesilicon-version").innerHTML = macVersions[1];
-  document.getElementById("macintel-version").innerHTML = macVersions[2];
+  document.getElementById("macuni-version").textContent = macVersions[0];
+  document.getElementById("macapplesilicon-version").textContent = macVersions[1];
+  document.getElementById("macintel-version").textContent = macVersions[2];
 
   document.getElementById("macuni-link").href = macLinks[0];
   document.getElementById("macapplesilicon-link").href = macLinks[1];
   document.getElementById("macintel-link").href = macLinks[2];
 
 
-  document.getElementById("linuxarm-appimage-version").innerHTML = linuxVersions[0];
-  document.getElementById("linuxx64-appimage-version").innerHTML = linuxVersions[1];
-  document.getElementById("linuxarm-binaries-version").innerHTML = linuxVersions[2];
-  document.getElementById("linuxx64-binaries-version").innerHTML = linuxVersions[3];
+  document.getElementById("linuxarm-appimage-version").textContent = linuxVersions[0];
+  document.getElementById("linuxx64-appimage-version").textContent = linuxVersions[1];
+  document.getElementById("linuxarm-binaries-version").textContent = linuxVersions[2];
+  document.getElementById("linuxx64-binaries-version").textContent = linuxVersions[3];
 
   document.getElementById("linuxarm-appimage-link").href = linuxLinks[0];
   document.getElementById("linuxx64-appimage-link").href = linuxLinks[1];

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -1,4 +1,4 @@
-const fallbackVersion = "1.0.0"
+const fallbackVersion = "test"
 
 const buildMatrix = {
   windows: {
@@ -333,10 +333,20 @@ function get_info(response){
     return;
   }
 
-  let newVersion = latestManualVersion;
+  let newVersion = fallbackVersion;
 
   if (response.hasOwnProperty("tag_name")){
-    newVersion = response.tag_name;
+    // Our tag names have the v, but in a lot of places we don't need it, so cut it off.
+    if (response.tag_name[0] === `v`){
+      newVersion = response.tag_name.slice(-response.tag_name.length + 1);
+    } else {
+      newVersion = response.tag_name;
+    }
+  }
+
+  // return if we already have this version.
+  if (newVersion === fallbackVersion){
+    return;
   }
 
   let x = 0;

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -1,67 +1,77 @@
-// Installer: ARM, x64, x86 THEN Portable: ARM, x64, x86
-const windowsLinks = [
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-arm64.ex", 
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-x64.exe", 
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10-x86.exe",
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_arm64.zip",
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_x64.zip",
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Windows_x86.zip"
-];
+const fallbackVersion = "1.0.0"
 
-const windowsVersions = [
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10"
-]
+const buildMatrix = {
+  windows: {
+    arm64Installer: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Knossos.NET-${fallbackVersion}-arm64.exe`,
+      version: `${fallbackVersion}`
+    },
+    x64Installer: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Knossos.NET-${fallbackVersion}-x64.exe`,
+      version: `${fallbackVersion}`
+    },
+    x86Installer: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Knossos.NET-${fallbackVersion}-x86.exe`,
+      version: `${fallbackVersion}`
+    },
+    arm64: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Windows_arm64.zip`,
+      version: `${fallbackVersion}`
+    },
+    x64: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Windows_x64.zip`,
+      version: `${fallbackVersion}`
+    },
+    x86: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Windows_x86.zip`,
+      version: `${fallbackVersion}`
+    }
+  },
+  linux: {
+    arm64Installer: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Knossos.NET-aarch64.AppImage`,
+      version: `${fallbackVersion}`
+    },
+    x64Installer: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Knossos.NET-x86_64.AppImage`,
+      version: `${fallbackVersion}`
+    },
+    arm64: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Linux_arm64.tar.gz`,
+      version: `${fallbackVersion}`
+    },
+    x64: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Linux_x64.tar.gz`,
+      version: `${fallbackVersion}`
+    }
+  },
+  macos: {
+    installer: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/Knossos.NET-${fallbackVersion}.dmg`,
+      version: `${fallbackVersion}`
+    },
+    appleSilicon: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/MacOS_arm64.tar.gz`,
+      version: `${fallbackVersion}`
+    },
+    intel: {
+      url: `https://github.com/KnossosNET/Knossos.NET/releases/download/v${fallbackVersion}/MacOS_x64.tar.gz`,
+      version: `${fallbackVersion}`
+    }
+  }
+}
 
-// Universal, then Apple Silicon, Then Intel
-const macLinks = [
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-0.2.0-RC10.dmg",
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/MacOS_arm64.tar.gz", 
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/MacOS_x64.tar.gz"
-];
 
-const macVersions = [
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10"
-]
-
-// Appimage: aarch64, x86_64 THEN Precombiled Binaries aarch64, x86_64
-const linuxLinks = [
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-aarch64.AppImage", 
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Knossos.NET-x86_64.AppImage",
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Linux_arm64.tar.gz",
-  "https://github.com/KnossosNET/Knossos.NET/releases/download/v0.2.0-RC10/Linux_x64.tar.gz"
-];
-
-const linuxVersions = [
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10",
-  "0.2.0-RC10"
-]
-
-const latestManualVersion = "0.2.0-RC10";
-
-// Run at the start of the page (called from the html) with our best guess at 
+// Run at the start of the page (called from the html) with our best guess at Architecture
 function initPage(arch){
   populateFields();
 
-  try{
-    fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
+  fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
     .then((response) => response.json())
     .then((responseJSON) => get_info(responseJSON))
-    .then(populateFields);
-  } 
-  catch (error) {
-    console.log("Fetching the most recent build from the github api failed. The error encountered was:")
-    console.error(error);
-  }
-
+    .then(populateFields)
+    .catch (error => console.log(`Fetching the most recent build from the github api failed. The error encountered was: ${error}`));
+  
   // still looking for a good ARM list.  Hopefully defaulting to ARM and detecting the other two is enough.
   const arch64List = ["EM64T", "x86-64", "Intel 64", "amd64"];
   const arch32List = ["ia32", "x86", "amd32"];
@@ -202,16 +212,16 @@ function activateTheButton(os, arch){
   // Windows
   if (os === 0) {
     if (arch === 0){
-      newContents += "Windows ARM64 Installer";
-      anchorElement.href = windowsLinks[0];
+      newContents += `${buildMatrix.windows.arm64Installer.version} Windows ARM64 Installer`;
+      anchorElement.href = buildMatrix.windows.arm64Installer.url;
 
     } else if (arch === 32) {
-      newContents +=  "Windows 32 Bit Installer";
-      anchorElement.href = windowsLinks[2];
+      newContents += `${buildMatrix.windows.x86Installer.version} Windows 32 Bit Installer`;
+      anchorElement.href = buildMatrix.windows.x86Installer.url;
     
     } else if (arch === 64) {
-      newContents +=  "Windows 64 Bit Intel Installer";
-      anchorElement.href = windowsLinks[1];
+      newContents += `${buildMatrix.windows.x64Installer.version} Windows 64 Bit Intel Installer`;
+      anchorElement.href = buildMatrix.windows.x64Installer.url;
 
     // Bogus Windows arch
     }  else {
@@ -224,14 +234,14 @@ function activateTheButton(os, arch){
 
     // Because of universal build, handle both situations at once.
     if (arch === 0 || arch === 64) {  
-      newContents += "Mac Universal DMG";
-      anchorElement.href = macLinks[0];
+      newContents += `${buildMatrix.macos.installer.version} macOS Universal DMG`;
+      anchorElement.href = buildMatrix.macos.installer.url;
 
     } else if (arch === 32) {
       // Unsuppoted
       disableTheButton();
 
-    // Bogus Mac Arch, (Or so old, we're wondering how they're still using it)
+    // Bogus Mac Arch (Or so old that we're wondering how they're still using it)
     } else {
       disableTheButton();
       return;
@@ -240,16 +250,16 @@ function activateTheButton(os, arch){
   // Linux
   } else if (os === 2) {
     if (arch === 0) {
-      newContents +=  "Linux aarch64 AppImage";
-      anchorElement.href = linuxLinks[0];
+      newContents +=  `${buildMatrix.linux.arm64Installer.version} Linux aarch64 AppImage`;
+      anchorElement.href = buildMatrix.linux.arm64Installer.url;
 
     } else if (arch === 32) {
         // Unsupported
         disableTheButton();
 
     } else if (arch === 64) {
-      newContents += "Linux x86_64 AppImage";
-      anchorElement.href = linuxLinks[1];
+      newContents += `${buildMatrix.linux.x64Installer.version} Linux x86_64 AppImage`;
+      anchorElement.href = buildMatrix.linux.x64.url;
 
     // Bogus Linux Arch
     } else {
@@ -278,39 +288,39 @@ function activateTheButton(os, arch){
 
 function populateFields(){
 
-  document.getElementById("winarm-installer-version").textContent = windowsVersions[0];
-  document.getElementById("winx64-installer-version").textContent = windowsVersions[1];
-  document.getElementById("winx86-installer-version").textContent = windowsVersions[2];
-  document.getElementById("winarm-pack-version").textContent = windowsVersions[3];
-  document.getElementById("winx64-pack-version").textContent = windowsVersions[4];
-  document.getElementById("winx86-pack-version").textContent = windowsVersions[5];
+  document.getElementById("winarm-installer-version").textContent = buildMatrix.windows.arm64Installer.version;
+  document.getElementById("winx64-installer-version").textContent = buildMatrix.windows.x64Installer.version;
+  document.getElementById("winx86-installer-version").textContent = buildMatrix.windows.x86Installer.version;
+  document.getElementById("winarm-pack-version").textContent = buildMatrix.windows.arm64.version;
+  document.getElementById("winx64-pack-version").textContent = buildMatrix.windows.x64.version;
+  document.getElementById("winx86-pack-version").textContent = buildMatrix.windows.x86.version;
 
-  document.getElementById("winarm-installer-link").href = windowsLinks[0];
-  document.getElementById("winx64-installer-link").href = windowsLinks[1];
-  document.getElementById("winx86-installer-link").href = windowsLinks[2];
-  document.getElementById("winarm-pack-link").href = windowsLinks[3];
-  document.getElementById("winx64-pack-link").href = windowsLinks[4];
-  document.getElementById("winx86-pack-link").href = windowsLinks[5];
-
-
-  document.getElementById("macuni-version").textContent = macVersions[0];
-  document.getElementById("macapplesilicon-version").textContent = macVersions[1];
-  document.getElementById("macintel-version").textContent = macVersions[2];
-
-  document.getElementById("macuni-link").href = macLinks[0];
-  document.getElementById("macapplesilicon-link").href = macLinks[1];
-  document.getElementById("macintel-link").href = macLinks[2];
+  document.getElementById("winarm-installer-link").href = buildMatrix.windows.arm64Installer.url;
+  document.getElementById("winx64-installer-link").href = buildMatrix.windows.x64Installer.url;
+  document.getElementById("winx86-installer-link").href = buildMatrix.windows.x86Installer.url;
+  document.getElementById("winarm-pack-link").href = buildMatrix.windows.arm64.url;
+  document.getElementById("winx64-pack-link").href = buildMatrix.windows.x64.url;
+  document.getElementById("winx86-pack-link").href = buildMatrix.windows.x86.url;
 
 
-  document.getElementById("linuxarm-appimage-version").textContent = linuxVersions[0];
-  document.getElementById("linuxx64-appimage-version").textContent = linuxVersions[1];
-  document.getElementById("linuxarm-binaries-version").textContent = linuxVersions[2];
-  document.getElementById("linuxx64-binaries-version").textContent = linuxVersions[3];
+  document.getElementById("macuni-version").textContent = buildMatrix.macos.installer.version;
+  document.getElementById("macapplesilicon-version").textContent = buildMatrix.macos.appleSilicon.version;
+  document.getElementById("macintel-version").textContent = buildMatrix.macos.intel.version;
 
-  document.getElementById("linuxarm-appimage-link").href = linuxLinks[0];
-  document.getElementById("linuxx64-appimage-link").href = linuxLinks[1];
-  document.getElementById("linuxarm-binaries-link").href = linuxLinks[2];
-  document.getElementById("linuxx64-binaries-link").href = linuxLinks[3];
+  document.getElementById("macuni-link").href = buildMatrix.macos.installer.url;
+  document.getElementById("macapplesilicon-link").href = buildMatrix.macos.appleSilicon.url;
+  document.getElementById("macintel-link").href = buildMatrix.macos.intel.url;
+
+
+  document.getElementById("linuxarm-appimage-version").textContent = buildMatrix.linux.arm64Installer.version;
+  document.getElementById("linuxx64-appimage-version").textContent = buildMatrix.linux.x64Installer.version;
+  document.getElementById("linuxarm-binaries-version").textContent = buildMatrix.linux.arm64.version;
+  document.getElementById("linuxx64-binaries-version").textContent = buildMatrix.linux.x64.version;
+
+  document.getElementById("linuxarm-appimage-link").href = buildMatrix.linux.arm64Installer.url;
+  document.getElementById("linuxx64-appimage-link").href = buildMatrix.linux.x64Installer.url;
+  document.getElementById("linuxarm-binaries-link").href = buildMatrix.linux.arm64.url;
+  document.getElementById("linuxx64-binaries-link").href = buildMatrix.linux.x64.url;
 }
 
 function get_info(response){

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -127,31 +127,33 @@ function disableTheButton(){
 
 
 function activateDownload(){
+  // turn on autodetect
+  changeActivation(true, "downLinks", "downTab")
 
   // turn off everything else
   changeActivation(false, "macLinks", "macTab");
   changeActivation(false, "linLinks", "linTab");
   changeActivation(false, "winLinks", "winTab");
-  changeActivation(true, "downLinks", "downTab")
 
 }
 
 function activateWindows(){
-//  console.log("Windows Chosen");
+  // turn on windows
+  changeActivation(true, "winLinks", "winTab");
 
   // turn off everything else
   changeActivation(false, "macLinks", "macTab");
   changeActivation(false, "linLinks", "linTab");
-  changeActivation(true, "winLinks", "winTab");
   changeActivation(false, "downLinks", "downTab")
 }
 
 function activateMac(){
+  // Turn on macOS
+  changeActivation(true, "macLinks", "macTab");
 
   // turn off everything else
   changeActivation(false, "linLinks", "linTab");
   changeActivation(false, "winLinks", "winTab");
-  changeActivation(true, "macLinks", "macTab");
   changeActivation(false, "downLinks", "downTab")
 }
 

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -51,10 +51,16 @@ const latestManualVersion = "0.2.0-RC10";
 function initPage(arch){
   populateFields();
 
-  fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
-  .then((response) => response.json())
-  .then((responseJSON) => get_info(responseJSON))
-  .then(populateFields);
+  try{
+    fetch("https://api.github.com/repos/KnossosNET/Knossos.NET/releases/latest")
+    .then((response) => response.json())
+    .then((responseJSON) => get_info(responseJSON))
+    .then(populateFields);
+  } 
+  catch (error) {
+    console.log("Fetching the most recent build from the github api failed. The error encountered was:")
+    console.error(error);
+  }
 
   // still looking for a good ARM list.  Hopefully defaulting to ARM and detecting the other two is enough.
   const arch64List = ["EM64T", "x86-64", "Intel 64", "amd64"];

--- a/main/js/download-scritps.js
+++ b/main/js/download-scritps.js
@@ -287,7 +287,6 @@ function activateTheButton(os, arch){
 }
 
 function populateFields(){
-
   document.getElementById("winarm-installer-version").textContent = buildMatrix.windows.arm64Installer.version;
   document.getElementById("winx64-installer-version").textContent = buildMatrix.windows.x64Installer.version;
   document.getElementById("winx86-installer-version").textContent = buildMatrix.windows.x86Installer.version;
@@ -346,44 +345,44 @@ function get_info(response){
     }
 
     if (response.assets[x].name.slice(-9)=== "arm64.exe"){
-      windowsVersions[0] = newVersion;
-      windowsLinks[0] = response.assets[x].browser_download_url;
+      buildMatrix.windows.arm64Installer.version = newVersion;
+      buildMatrix.windows.arm64Installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name.slice(-7)==="x64.exe"){
-      windowsVersions[1] = newVersion;
-      windowsLinks[1] = response.assets[x].browser_download_url;
+      buildMatrix.windows.x64Installer.version = newVersion;
+      buildMatrix.windows.x64Installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name.slice(-7)==="x86.exe"){
-      windowsVersions[2] = newVersion;
-      windowsLinks[2] = response.assets[x].browser_download_url;
+      buildMatrix.windows.x86Installer.version = newVersion;
+      buildMatrix.windows.x86Installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name.slice(-4)===".dmg"){
-      macVersions[0] = newVersion;
-      macLinks[0] = response.assets[x].browser_download_url;
+      buildMatrix.macos.installer.version = newVersion;
+      buildMatrix.macos.installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name.slice(-16)==="aarch64.AppImage"){
-      linuxVersions[0] = newVersion;
-      linuxLinks[0] = response.assets[x].browser_download_url;
+      buildMatrix.linux.arm64Installer.version = newVersion;
+      buildMatrix.linux.arm64Installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name.slice(-15)==="x86_64.AppImage"){
-      linuxVersions[1] = newVersion;
-      linuxLinks[1] = response.assets[x].browser_download_url;
+      buildMatrix.linux.x64Installer.version = newVersion;
+      buildMatrix.linux.x64Installer.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="Linux_arm64.tar.gz"){
-      linuxVersions[2] = newVersion;
-      linuxLinks[2] = response.assets[x].browser_download_url;
+      buildMatrix.linux.arm64.version = newVersion;
+      buildMatrix.linux.arm64.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="Linux_x64.tar.gz"){
-      linuxVersions[3] = newVersion;
-      linuxLinks[3] = response.assets[x].browser_download_url;
+      buildMatrix.linux.x64.version = newVersion;
+      buildMatrix.linux.x64.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="MacOS_arm64.tar.gz"){
-      macVersions[1] = newVersion;
-      macLinks[1] = response.assets[x].browser_download_url;
+      buildMatrix.macos.appleSilicon.version = newVersion;
+      buildMatrix.macos.appleSilicon.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="MacOS_x64.tar.gz"){
-      macVersions[2] = newVersion;
-      macLinks[2] = response.assets[x].browser_download_url;
+      buildMatrix.macos.intel.version = newVersion;
+      buildMatrix.macos.intel.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="Windows_arm64.zip"){
-      windowsVersions[3] = newVersion;
-      windowsLinks[3] = response.assets[x].browser_download_url;
+      buildMatrix.windows.arm64.version = newVersion;
+      buildMatrix.windows.arm64.url = response.assets[x].browser_download_url;
     } else if (response.assets[x].name==="Windows_x64.zip"){
-      windowsVersions[4] = newVersion;
-      windowsLinks[4] = response.assets[x].browser_download_url;      
+      buildMatrix.windows.x64.version = newVersion;
+      buildMatrix.windows.x64.url = response.assets[x].browser_download_url;      
     } else if (response.assets[x].name==="Windows_x86.zip"){
-      windowsVersions[5] = newVersion;
-      windowsLinks[5] = response.assets[x].browser_download_url;      
+      buildMatrix.windows.x86.version = newVersion;
+      buildMatrix.windows.x86.url = response.assets[x].browser_download_url;      
     }
     x++;
   }


### PR DESCRIPTION
This allows us to pull the latest release from github.  I will still update the page with major releases so that there is a default build available for each category.

Fixes #2 