### PR TITLE
Add OpenGraph meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-
+    
+    <!-- OpenGraph -->
+    <meta property="og:title" content="Knossos.NET Downloads" />
+    <meta property="og:description" content="Download Knossos.NET, an easy way to install FreeSpace Open and its mods." />
+    <meta property="og:image" content="main/res/knossos-icon.png" />
+    <meta property="og:image:width" content="128" />
+    <meta property="og:image:height" content="128" />
+    <meta property="og:image:alt" content="Knossos.NET Icon" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://knossosnet.github.io/Knossos-Release-Page/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    
     <!-- Bootstrap CSS -->
 
     <link href="main/res/bootstrap/css/bootstrap.min.css" rel="stylesheet" />


### PR DESCRIPTION
Hi folks! Longtime fan of the SCP, and super thankful for Knossos.net for how awesome it is to play FS1/2 and take advantage of the mods made for it. 

Was sharing Knossos with friends via Discord, and found that the page didn't include OpenGraph (https://ogp.me/) meta tags to enable rich link previews. Some folks like them, some folks don't care about them, and some folks get weirdly angry about them, but IMO they're a boon, so I thought I'd whip up a quick PR to add them. 

Feel free to accept or reject based on your preferences - I certainly won't be offended. Thanks again for helping to keep this niche game and its community alive!